### PR TITLE
Add envrionment variable for nebular database.

### DIFF
--- a/pkg/analysis/analysis.cl
+++ b/pkg/analysis/analysis.cl
@@ -9,6 +9,7 @@ begin
 	set fourier    = "analysis$fourier/"
 	set isophote   = "analysis$isophote/"
         set nebular    = "analysis$nebular/"
+        set at_data    = "nebular$atomic_data/"
 
 	package analysis
 


### PR DESCRIPTION
The recent merge of nebular package missed an environment variable to indicate the directory that stores nebular's database. This environment variable exists in the [original stsdas file](https://github.com/iraf-community/stsdas/blob/main/stsdas/pkg/analysis/analysis.cl).